### PR TITLE
Added configuration to calculate md5 checksum of the zip file

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -155,6 +155,7 @@
                                 </zip>
                                 <chmod file="${target.dir}.zip" perm="777"/>
                                 <delete dir="${target.dir}"/>
+                                <checksum file="${target.dir}-${project.version}.zip" pattern="{0} {1}"/>
                             </target>
                         </configuration>
                         <goals>


### PR DESCRIPTION
Added configuration to calculate md5 checksum of the zip file. This md5 checksum value can be validated before deploying the ssl monitoring extension in your infrastructure to ensure no file tampering has been done. This improves security aspect of this monitoring extension.